### PR TITLE
Unmount on a (second) signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for libfuse3
 
+## 0.1.1.0 -- 2020-08-29
+
+* Improve the situation with signals
+  * Now possible to unmount the filesystem with signals, but have to be sent twice.
+
 ## 0.1.0.0 -- 2020-08-27
 
 * First version. Released on an unsuspecting world.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ cabal v2-configure --flags=examples
 
 ## Known issues and limitations
 
-- Can't stop the process and unmount with signals. You have to use `fusermount -u` to unmount.
+- A signal needs to be sent twice to stop the process and unmount the filesystem.
+  - This means you have to run `kill -2 <pid>` twice or hit `Ctrl-C` twice (if running in foreground).
+  - On the other hand, `fusermount -u` can unmount the filesystem on the first attempt.
 - Not all Haskell-friendly bindings to the FUSE operations are implemented yet, including but not limited to:
   - `struct fuse_conn_info`. The availability of filesystem capabilities such as `FUSE_CAP_HANDLE_KILLPRIV` can't be checked.
   - Setting the fields of `struct fuse_file_info` from the certain fuse operations.
 - Look for the `TODO` comments in the source tree for more specific topics.
 
-If you are able to implement any of these, that would be very appreciated! Please open a PR to contribute.
+If you are able to fix/implement any of these, that would be very appreciated! Please open a PR to contribute.
 
 ## Related works
 

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -887,7 +887,7 @@ withSignalHandlers :: IO () -> IO a -> IO a
 withSignalHandlers exitHandler = bracket_ setHandlers resetHandlers
   where
   setHandlers = do
-    let sigHandler = Signals.CatchOnce exitHandler
+    let sigHandler = Signals.Catch exitHandler
     void $ Signals.installHandler Signals.sigINT  sigHandler Nothing
     void $ Signals.installHandler Signals.sigHUP  sigHandler Nothing
     void $ Signals.installHandler Signals.sigTERM sigHandler Nothing


### PR DESCRIPTION
Previously, applications dropped the first signal and abruptly exited at the second one. The situation is better now as apps now properly run the `fuseDestroy` method and unmount the filesystem. Two signals are still needed, though.