### PR TITLE
Mention fusermount3 instead of fusermount in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for libfuse3
 
+## 0.1.1.1 -- unreleased
+
+* Minor improvements on the documentations
+
 ## 0.1.1.0 -- 2020-08-29
 
 * Improve the situation with signals

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cabal v2-configure --flags=examples
 
 - A signal needs to be sent twice to stop the process and unmount the filesystem.
   - This means you have to run `kill -2 <pid>` twice or hit `Ctrl-C` twice (if running in foreground).
-  - On the other hand, `fusermount -u` can unmount the filesystem on the first attempt.
+  - On the other hand, `fusermount3 -u` can unmount the filesystem on the first attempt.
 - Not all Haskell-friendly bindings to the FUSE operations are implemented yet, including but not limited to:
   - `struct fuse_conn_info`. The availability of filesystem capabilities such as `FUSE_CAP_HANDLE_KILLPRIV` can't be checked.
   - Setting the fields of `struct fuse_file_info` from the certain fuse operations.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Haskell libfuse3 package], [0.1.1.0])
+AC_INIT([Haskell libfuse3 package], [0.1.1.1])
 
 # Safety check: Ensure that we are in the correct source directory.
 AC_CONFIG_SRCDIR([libfuse3.cabal])

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                libfuse3
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            A Haskell binding for libfuse-3.x
 description:         Bindings for libfuse, the FUSE userspace reference implementation, of version 3.x. Compatible with Linux.
 -- bug-reports:

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -954,22 +954,6 @@ fuseRun prog args ops handler = runResourceT $ do
 -- This is all that has to be called from the @main@ function. On top of
 -- the `FuseOperations` record with filesystem implementation, you must give
 -- an exception handler converting Haskell exceptions to `Errno`.
---
--- This function does the following:
---
---   * parses command line options
---
---   * passes all options after @--@ to the fusermount3 program
---
---   * mounts the filesystem by calling @fusermount3@
---
---   * installs signal handlers
---
---   * registers an exit handler to unmount the filesystem on program exit
---
---   * registers the operations
---
---   * calls FUSE event loop
 fuseMain :: Exception e => FuseOperations fh dh -> (e -> IO Errno) -> IO ()
 fuseMain ops handler = do
   -- this used to be implemented using libfuse's fuse_main. Doing this will fork()

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -928,7 +928,7 @@ fuseMainReal = \pFuse (foreground, mountPt, cloneFd) -> do
     -- is unmounted.
     -- Adding the RTS option @--install-signal-handlers=no@ does not fix the issue.
     --
-    -- On the other hand, @fusermount -u@ successfully unmounts the filesystem on the first
+    -- On the other hand, @fusermount3 -u@ successfully unmounts the filesystem on the first
     -- attempt.
     withSignalHandlers (C.fuse_session_exit session) $ do
       retVal <- C.fuse_loop_mt_31 pFuse cloneFd
@@ -959,9 +959,9 @@ fuseRun prog args ops handler = runResourceT $ do
 --
 --   * parses command line options
 --
---   * passes all options after @--@ to the fusermount program
+--   * passes all options after @--@ to the fusermount3 program
 --
---   * mounts the filesystem by calling @fusermount@
+--   * mounts the filesystem by calling @fusermount3@
 --
 --   * installs signal handlers
 --


### PR DESCRIPTION
`fusermount` is a command from fuse2 which appears to be compatible with fuse3. `fusermount3` is the correct one.

`README.md` and the Haddock comments are updated to mention `fusermount3`.