### PR TITLE
Add a very basic set of tests

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install -y libfuse3-dev fuse3
 
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1.1
+    - uses: actions/setup-haskell@v1
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install libfuse3
       run: |
         sudo apt-get update
-        sudo apt-get install -y libfuse3-dev
+        sudo apt-get install -y libfuse3-dev fuse3
 
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1.1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -75,6 +75,5 @@ jobs:
         ~/.cabal/bin/cabal-bounds update -o b.cabal
         diff a.cabal b.cabal
 
-    # there are no tests yet
-    # - name: Run tests
-    #   run: cabal v2-test all
+    - name: Run tests
+      run: cabal v2-run -- integtest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -72,7 +72,7 @@ jobs:
         cabal v2-build --allow-newer # generate dist-newstyle/cache/plan.json which cabal-bounds depends on
         cabal v2-install --overwrite-policy=always cabal-bounds
         ~/.cabal/bin/cabal-bounds format -o a.cabal
-        ~/.cabal/bin/cabal-bounds update -o b.cabal
+        ~/.cabal/bin/cabal-bounds update -o b.cabal --library
         diff a.cabal b.cabal
 
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This package depends on the C library [libfuse][libfuse] and `pkg-config`. Please install them with your system package manager before building this package. For example, on Ubuntu:
 
 ```sh
-sudo apt-get update && sudo apt-get install libfuse3-dev pkg-config
+sudo apt-get update && sudo apt-get install libfuse3-dev fuse3 pkg-config
 ```
 
 **NOTE:** `libfuse3-dev` is not available until Ubuntu-20.04 (a.k.a. "focal").

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -53,6 +53,19 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall -fdefer-typed-holes
 
+test-suite integtest
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  build-depends:       libfuse3, base
+                     , process
+                     , temporary
+                     , unix
+  -- other-modules:
+  -- other-extensions:
+  hs-source-dirs:      test/integtest
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fdefer-typed-holes -threaded
+
 executable null
   if flag(examples)
     buildable: True

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -57,6 +57,9 @@ test-suite integtest
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   build-depends:       libfuse3, base
+                     , HUnit
+                     , bytestring
+                     , filepath
                      , process
                      , temporary
                      , unix

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -59,6 +59,7 @@ test-suite integtest
   build-depends:       libfuse3, base
                      , HUnit
                      , bytestring
+                     , directory
                      , filepath
                      , process
                      , temporary

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -57,10 +57,10 @@ test-suite integtest
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   build-depends:       libfuse3, base
-                     , HUnit
                      , bytestring
                      , directory
                      , filepath
+                     , hspec
                      , process
                      , temporary
                      , unix

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -2,7 +2,6 @@ module Main where
 
 import Control.Exception (SomeException, finally)
 import Data.Bits ((.|.))
-import Data.Void (Void)
 import Foreign.C (eIO, eNOENT)
 import System.Environment (withArgs)
 import System.FilePath ((</>))
@@ -25,17 +24,17 @@ runTestCase :: TestCase fh dh -> IO ()
 runTestCase TestCase{testCaseOps=ops, testCaseProg=prog} =
   withSystemTempDirectory "libfuse3test" $ \mountPoint -> do
     let unmount = do
-          hPutStrLn stderr $ "unmounting: " <> mountPoint
+          hPutStrLn stderr $ "unmounting : " <> mountPoint
           callProcess "fusermount3" ["-u", mountPoint]
     withArgs [mountPoint] $ do
-      hPutStrLn stderr $ "mounting a test filesystem on: " <> mountPoint
+      hPutStrLn stderr $ "mounting on: " <> mountPoint
       pid <- forkProcess $ fuseMain ops (\e -> hPrint stderr (e :: SomeException) >> pure eIO)
       flip finally unmount $ do
         -- wait for fuseMain to daemonize
         _ <- getProcessStatus True False pid
         prog mountPoint
 
-getattrTest :: TestCase Void Void
+getattrTest :: TestCase fh dh
 getattrTest =
   let stat = defaultFileStat
         { fileMode = directoryMode .|. 0o644 -- TODO 0o755
@@ -54,7 +53,7 @@ getattrTest =
         -- ignore differences in fileID
         -- TODO test use_ino?
         let stat'' = stat' { fileID = fileID stat }
-        print $ stat == stat''
+        assertEqual "getattrTest" stat stat''
   in TestCase ops prog
 
 -- | If `fuseOpen` is not defined, make sure that `fuseRead` doesn't throw unless

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -1,28 +1,57 @@
 module Main where
 
-import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, finally)
+import Data.Bits ((.|.))
 import Data.Void (Void)
-import Foreign.C (eIO)
+import Foreign.C (eIO, eNOENT)
 import System.Environment (withArgs)
 import System.IO (hPrint, hPutStrLn, stderr)
 import System.IO.Temp (withSystemTempDirectory)
-import System.LibFuse3 (FuseOperations, defaultFuseOperations, fuseMain)
+import System.LibFuse3
+import System.Posix.Files (directoryMode)
 import System.Posix.Process (getProcessStatus, forkProcess)
 import System.Process (callProcess)
 
-ops :: FuseOperations Void Void
-ops = defaultFuseOperations
+data TestCase fh dh = TestCase
+  { testCaseOps :: FuseOperations fh dh
+  , testCaseProg :: FilePath -> IO ()
+  }
+
+runTestCase :: TestCase fh dh -> IO ()
+runTestCase TestCase{testCaseOps=ops, testCaseProg=prog} =
+  withSystemTempDirectory "libfuse3test" $ \mountPoint -> do
+    let unmount = do
+          hPutStrLn stderr $ "unmounting: " <> mountPoint
+          callProcess "fusermount3" ["-u", mountPoint]
+    withArgs [mountPoint] $ do
+      hPutStrLn stderr $ "mounting a test filesystem on: " <> mountPoint
+      pid <- forkProcess $ fuseMain ops (\e -> hPrint stderr (e :: SomeException) >> pure eIO)
+      flip finally unmount $ do
+        -- wait for fuseMain to daemonize
+        _ <- getProcessStatus True False pid
+        prog mountPoint
+
+getattrTest :: TestCase Void Void
+getattrTest =
+  let stat = defaultFileStat
+        { fileMode = directoryMode .|. 0o644
+        , linkCount = 1
+        }
+
+      ops = defaultFuseOperations
+        { fuseGetattr = Just $ \path _ -> case path of
+            "/" -> pure $ Right stat
+            _ -> pure $ Left eNOENT
+        }
+
+      prog = \mountPoint -> do
+        -- assumes that `getFileStat` works correctly
+        stat' <- getFileStat mountPoint
+        -- ignore differences in fileID
+        -- TODO test use_ino?
+        let stat'' = stat' { fileID = fileID stat }
+        print $ stat == stat''
+  in TestCase ops prog
 
 main :: IO ()
-main = withSystemTempDirectory "libfuse3test" $ \mountPoint -> do
-  let unmount = do
-        hPutStrLn stderr $ "unmounting: " <> mountPoint
-        callProcess "fusermount3" ["-u", mountPoint]
-
-  withArgs [mountPoint] $ do
-    hPutStrLn stderr $ "mounting a test filesystem on: " <> mountPoint
-    pid <- forkProcess $ fuseMain ops (\e -> hPrint stderr (e :: SomeException) >> pure eIO)
-    flip finally unmount $ do
-      _ <- getProcessStatus True False pid
-      threadDelay $ 10 * 1000 * 1000
+main = runTestCase getattrTest

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -37,6 +37,7 @@ withFileSystem ops = around $ \theSpec ->
 
 main :: IO ()
 main = hspec $ do
+  -- A basic test of fuseGetattr; we get what we give
   describe "fuseGetattr" $
     let stat = defaultFileStat
           { fileMode = directoryMode .|. 0o755
@@ -69,6 +70,7 @@ main = hspec $ do
                       }
                   | otherwise -> pure $ Left eNOENT
           , fuseRead = Just $ \path _fh len off ->
+              -- check that evaluating the args other than the file handle is harmless
               path `seq` len `seq` off `seq` (pure $ Right content)
           }
     in withFileSystem ops $ it "fileRead reads without a crash" $ \mountPoint -> do

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -1,3 +1,7 @@
+-- Please note that @cabal v2-test@ handles the test output very badly for some reason;
+-- the output is duplicated and interleaved.
+--
+-- Use @call v2-run -- integtest@ for more reliable output.
 module Main where
 
 import Control.Exception (SomeException, finally)

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -1,0 +1,28 @@
+module Main where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, finally)
+import Data.Void (Void)
+import Foreign.C (eIO)
+import System.Environment (withArgs)
+import System.IO (hPrint, hPutStrLn, stderr)
+import System.IO.Temp (withSystemTempDirectory)
+import System.LibFuse3 (FuseOperations, defaultFuseOperations, fuseMain)
+import System.Posix.Process (getProcessStatus, forkProcess)
+import System.Process (callProcess)
+
+ops :: FuseOperations Void Void
+ops = defaultFuseOperations
+
+main :: IO ()
+main = withSystemTempDirectory "libfuse3test" $ \mountPoint -> do
+  let unmount = do
+        hPutStrLn stderr $ "unmounting: " <> mountPoint
+        callProcess "fusermount3" ["-u", mountPoint]
+
+  withArgs [mountPoint] $ do
+    hPutStrLn stderr $ "mounting a test filesystem on: " <> mountPoint
+    pid <- forkProcess $ fuseMain ops (\e -> hPrint stderr (e :: SomeException) >> pure eIO)
+    flip finally unmount $ do
+      _ <- getProcessStatus True False pid
+      threadDelay $ 10 * 1000 * 1000

--- a/test/integtest/Main.hs
+++ b/test/integtest/Main.hs
@@ -1,7 +1,7 @@
 -- Please note that @cabal v2-test@ handles the test output very badly for some reason;
 -- the output is duplicated and interleaved.
 --
--- Use @call v2-run -- integtest@ for more reliable output.
+-- Use @cabal v2-run -- integtest@ for more reliable output.
 module Main where
 
 import Control.Exception (SomeException, finally)


### PR DESCRIPTION
Added an Hspec testsuite `integtest`. The tests mounts filesystems onto the real filesystem, so it's considered an integration test, hence the name.

Currently only a very basic set of tests are implemented. One of the test tries the basic usage of `fuseGetattr`. The others cover the pain point of the current `libfuse3` API; `fuseRead` without `fuseOpen` and `fuseReaddir` without `fuseOpendir` shouldn't trigger runtime errors and/or some nasty bugs. (Currently they are implemented with unevaluated `fromJust` thunks.)

Also updated the README to mention the `fuse3` package, which installs the `fusermount3` command to allow unmounting FUSE filesystems.
