### PR TITLE
Add utility functions that help catching and throwing errnos

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -76,4 +76,6 @@ jobs:
         diff a.cabal b.cabal
 
     - name: Run tests
-      run: cabal v2-run -- integtest
+      run: |
+        cabal v2-run -- unittest
+        cabal v2-run -- integtest

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -53,6 +53,17 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall -fdefer-typed-holes
 
+test-suite unittest
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  build-depends:       libfuse3, base
+                     , hspec
+  -- other-modules:
+  -- other-extensions:
+  hs-source-dirs:      test/unittest
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fdefer-typed-holes -threaded
+
 test-suite integtest
   type:                exitcode-stdio-1.0
   main-is:             Main.hs

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -792,6 +792,9 @@ resCFuseOperations ops handler = do
           _ -> Left eINVAL
     either (pure . Left) (go filePath fh offset) emode
 
+  _dummyToSuppressWarnings :: StablePtr a
+  _dummyToSuppressWarnings = error "dummy" eNOSYS
+
 -- | Allocates a @fuse_args@ struct to hold commandline arguments.
 resFuseArgs :: String -> [String] -> ResourceT IO (Ptr C.FuseArgs)
 resFuseArgs prog args = do
@@ -1018,7 +1021,3 @@ delFH pFuseFileInfo = do
 -- | Materializes the callback of @readdir@ to marshal `fuseReaddir`.
 foreign import ccall "dynamic"
   peekFuseFillDir :: FunPtr C.FuseFillDir -> C.FuseFillDir
-
--- | the dummy to please both ghc and haddock; don't use
-_dummy :: StablePtr a -> b
-_dummy _ = undefined eNOSYS

--- a/src/System/LibFuse3/Utils.hs
+++ b/src/System/LibFuse3/Utils.hs
@@ -103,5 +103,3 @@ pokeCStringLen0 (pBuf, bufSize) src =
 -- @
 testBitSet :: Bits a => a -> a -> Bool
 testBitSet bits mask = bits .&. mask == mask
-
-

--- a/src/System/LibFuse3/Utils.hs
+++ b/src/System/LibFuse3/Utils.hs
@@ -43,7 +43,7 @@ ioErrorToErrno _ = Nothing
 
 -- | Like `throwErrno` but takes an `Errno` as a parameter instead of reading from `getErrno`.
 --
--- This is an inverse of `tryErrno`: TODO write a property test for this
+-- This is an inverse of `tryErrno`:
 --
 -- @
 -- tryErrno (throwErrnoOf _ e) ≡ pure (Left e)

--- a/src/System/LibFuse3/Utils.hs
+++ b/src/System/LibFuse3/Utils.hs
@@ -50,8 +50,7 @@ throwErrnoOf
   -> IO a
 throwErrnoOf loc errno = ioError (errnoToIOError loc errno Nothing Nothing)
   where
-  -- to supress unused warnings
-  _dummyToSuppressError = error "dummy" getErrno throwErrno
+  _dummyToSuppressWarnings = error "dummy" getErrno throwErrno
 
 -- | Catches an exception constructed with `errnoToIOError` and extracts `Errno` from it.
 tryErrno :: IO a -> IO (Either Errno a)

--- a/test/unittest/Main.hs
+++ b/test/unittest/Main.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Main where
+
+import Foreign.C (Errno(Errno), eIO)
+import System.LibFuse3
+import Test.Hspec (describe, hspec, it, shouldReturn)
+
+deriving instance Show Errno
+
+main :: IO ()
+main = hspec $ do
+  describe "throwErrnoOf" $ do
+    it "should be an inverse of `tryErrno`" $
+      tryErrno (throwErrnoOf "" eIO) `shouldReturn` (Left eIO :: Either Errno ())
+
+    it "should be an inverse of `tryErrno_`" $
+      tryErrno_ (throwErrnoOf "" eIO) `shouldReturn` eIO


### PR DESCRIPTION
Adds utility functions which I find useful to write libfuse3 applications.

- `throwErrnoOf`: Takes `Errno` to throw `IOError`
- `tryErrno'`, `tryErrno_'`: Catches non-errno exceptions as well to return `eIO`
