### PR TITLE
Catch every exception thrown by FUSE methods in resCFuseOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `throwErrnoOf`, `tryErrno'` and `tryErrno_'` to `System.Libfuse3.Utils`
 * Add `ExceptionHandler` and `defaultExceptionHandler`
+* Fix a bug in `resCFuseOperations` to prevent Haskell exceptions from escaping to C land
 
 ## 0.1.1.1 -- 2020-10-06
 

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -7,7 +7,7 @@
 module System.LibFuse3.Internal where
 
 import Control.Applicative ((<|>))
-import Control.Exception (Exception, SomeException, bracket_, finally, fromException, handle)
+import Control.Exception (Exception, SomeException, bracket_, catch, finally, fromException, handle)
 import Control.Monad (unless, void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
@@ -463,7 +463,7 @@ resCFuseOperations ops handlerRaw = do
   handler :: ExceptionHandler SomeException
   handler se = case fromException se of
     Nothing -> defaultExceptionHandler se
-    Just e -> handlerRaw e
+    Just e -> handlerRaw e `catch` defaultExceptionHandler
 
   -- convert a Haskell function to C one with @wrapMeth@, get its @FunPtr@, and associate it with freeHaskellFunPtr
   resC :: (cfunc -> IO (FunPtr cfunc)) -> (hsfunc -> cfunc) -> Maybe hsfunc -> ResourceT IO (FunPtr cfunc)

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -395,7 +395,7 @@ mergeLFuseOperations
 --
 -- The created `C.FuseOperations` has the following invariants:
 --
---   - The content of @fuse_operations.fh@ is a Haskell value of type @StablePtr fh@ or
+--   - The content of @fuse_file_info.fh@ is a Haskell value of type @StablePtr fh@ or
 --     @StablePtr dh@, depending on operations. It is created with `newFH`, accessed with
 --     `getFH` and released with `delFH`.
 --


### PR DESCRIPTION
If the supplied exception handler ignores an exception, it is catched nonetheless and logged to prevent it from escaping to the C land (the caller is libfuse).

I consider this as a bug fix, not a behavior change. The reason is that propagating Haskell exceptions to the C land leads to undefined behavior, which is by no means justifiable.
