### PR TITLE
Add bindings to pread and pwrite

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,7 +53,7 @@ jobs:
         cabal v2-sdist
         tar -xf dist-newstyle/sdist/libfuse3-*.tar.gz
         cd libfuse3-*/
-        cabal v2-configure --flags=examples --enable-tests --enable-benchmarks --enable-documentation
+        cabal v2-configure --flags=examples --enable-tests --enable-documentation
         # avoid building the documentations of the certain dependencies with ghc-8.4 because it crashes haddock
         case "$(ghc --numeric-version)" in
           8.4*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 0.1.2.0 -- Unreleased
 
-* Add `throwErrnoOf`, `tryErrno'` and `tryErrno_'` to `System.Libfuse3.Utils`
-* Add `ExceptionHandler` and `defaultExceptionHandler`
-* Fix a bug in `resCFuseOperations` to prevent Haskell exceptions from escaping to C land
+* Added `throwErrnoOf`, `tryErrno'` and `tryErrno_'` to `System.Libfuse3.Utils` (#5)
+* Added `ExceptionHandler` and `defaultExceptionHandler` (#6)
+* Fixed a bug in `resCFuseOperations` to prevent Haskell exceptions from escaping to C land (#7)
+* Added `pread` and `pwrite` to `System.Libfuse3.Utils` (#8)
 
 ## 0.1.1.1 -- 2020-10-06
 

--- a/bench/microbench/Main.hs
+++ b/bench/microbench/Main.hs
@@ -1,0 +1,40 @@
+module Main where
+
+import Control.Exception (bracket, onException)
+import Criterion.Main (bench, bgroup, defaultMain, nfIO)
+import Data.ByteString (ByteString)
+import Foreign (allocaBytes, free, mallocBytes)
+import System.LibFuse3.Utils
+import System.Posix.IO (OpenMode(ReadOnly), closeFd, defaultFileFlags, openFd)
+import System.Posix.Types (ByteCount, Fd(Fd), FileOffset)
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Unsafe as BU
+
+preadAlloca :: Fd -> ByteCount -> FileOffset -> IO ByteString
+preadAlloca (Fd fd) size off =
+  allocaBytes (fromIntegral size) $ \buf -> do
+    readBytes <- c_pread fd buf size off
+    B.packCStringLen (buf, fromIntegral readBytes)
+
+preadMalloc :: Fd -> ByteCount -> FileOffset -> IO ByteString
+preadMalloc (Fd fd) size off = do
+  buf <- mallocBytes (fromIntegral size)
+  let mkBS = do
+        readBytes <- c_pread fd buf size off
+        BU.unsafePackMallocCStringLen (buf, fromIntegral readBytes)
+  mkBS `onException` free buf
+
+main :: IO ()
+main = bracket
+  (openFd "/dev/zero" ReadOnly Nothing defaultFileFlags)
+  closeFd
+  $ \fd -> defaultMain
+    [ bgroup "pread"
+      [ bench "alloca" $ nfIO (preadAlloca fd size off)
+      , bench "malloc" $ nfIO (preadMalloc fd size off)
+      ]
+    ]
+  where
+  size = 1048576
+  off = 1024

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -81,6 +81,18 @@ test-suite integtest
   default-language:    Haskell2010
   ghc-options:         -Wall -fdefer-typed-holes -threaded
 
+benchmark microbench
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  -- other-modules:
+  build-depends:       libfuse3, base
+                     , bytestring
+                     , criterion
+                     , unix
+  hs-source-dirs:      bench/microbench
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fdefer-typed-holes -threaded
+
 executable null
   if flag(examples)
     buildable: True

--- a/src/System/LibFuse3/Utils.hs
+++ b/src/System/LibFuse3/Utils.hs
@@ -114,7 +114,7 @@ testBitSet bits mask = bits .&. mask == mask
 -- | Reads from a file descriptor at a given offset.
 --
 -- Fewer bytes may be read than requested.
--- On error, throws an `IOError` corresponding to the errno.
+-- On error, throws an t`IOError` corresponding to the errno.
 pread :: Fd -> ByteCount -> FileOffset -> IO ByteString
 pread (Fd fd) size off =
   allocaBytes (fromIntegral size) $ \buf -> do
@@ -124,7 +124,7 @@ pread (Fd fd) size off =
 -- | Writes to a file descriptor at a given offset.
 --
 -- Returns the number of bytes written. Fewer bytes may be written than requested.
--- On error, throws an `IOError` corresponding to the errno.
+-- On error, throws an t`IOError` corresponding to the errno.
 pwrite :: Fd -> ByteString -> FileOffset -> IO CSsize
 pwrite (Fd fd) bs off =
   BU.unsafeUseAsCStringLen bs $ \(buf, size) ->

--- a/src/System/LibFuse3/Utils.hs
+++ b/src/System/LibFuse3/Utils.hs
@@ -114,7 +114,6 @@ testBitSet bits mask = bits .&. mask == mask
 -- | Reads from a file descriptor at a given offset.
 pread :: Fd -> ByteCount -> FileOffset -> IO ByteString
 pread (Fd fd) size off =
-  -- TODO benchmark (allocaBytes + packCStringLen) vs (mallocBytes + unsafePackMallocCString)
   allocaBytes (fromIntegral size) $ \buf -> do
     readBytes <- c_pread fd buf size off
     B.packCStringLen (buf, fromIntegral readBytes)


### PR DESCRIPTION
I find it is useful to have them in `System.LibFuse3.Utils` module because to implement `fuseRead` / `fuseWrite` one needs to read from / write to files with some offsets, but there are no counterparts in the `unix` package.
