### PR TITLE
Extend upper bounds of deps and remove the cabal-bounds trick

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -68,12 +68,7 @@ jobs:
         cabal v2-haddock
 
     - name: Check version bounds
-      run: |
-        cabal v2-build --allow-newer # generate dist-newstyle/cache/plan.json which cabal-bounds depends on
-        cabal v2-install --overwrite-policy=always cabal-bounds
-        ~/.cabal/bin/cabal-bounds format -o a.cabal
-        ~/.cabal/bin/cabal-bounds update -o b.cabal --library
-        diff a.cabal b.cabal
+      run: cabal outdated --exit-code
 
     - name: Run tests
       run: |

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -45,7 +45,7 @@ library
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*
-                     , time >=1.6 && <1.10
+                     , time >=1.6 && <1.12
                      , unix ==2.7.*
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -42,7 +42,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.11 && <4.15
-                     , bytestring >=0.10.8 && <0.11
+                     , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*
                      , time >=1.6 && <1.10


### PR DESCRIPTION
Since `unix-2.7.2.2` now allows `bytestring-0.11` and `time-1.11`, libfuse3 is buildable with them.

Confirmed that the library and the tests are buildable and the tests pass. (requires `--allow-newer` because `directory` requires `time<1.11`)

The `cabal-bounds` trick hadn't detected it, presumably because the packages were installed into the global DB. I found that `cabal outdated --exit-code` does the work as exactly as I wanted; check if the upper bound is not the latest, and exit nonzero.