### PR TITLE
Add support for ghc-9.0.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.3']
+        ghc: ['8.8.4', '8.10.3', '9.0.1']
         cabal: ['3.4.0.0']
 
       fail-fast: false
@@ -59,18 +59,6 @@ jobs:
         tar -xf dist-newstyle/sdist/libfuse3-*.tar.gz
         cd libfuse3-*/
         cabal v2-configure --flags=examples --enable-tests --enable-documentation
-        # avoid building the documentations of the certain dependencies with ghc-8.4 because it crashes haddock
-        case "$(ghc --numeric-version)" in
-          8.4*)
-            echo ''                       >> cabal.project.local
-            echo 'package aeson'          >> cabal.project.local
-            echo '  documentation: False' >> cabal.project.local
-            echo 'package vector'         >> cabal.project.local
-            echo '  documentation: False' >> cabal.project.local
-            ;;
-          *)
-            ;;
-        esac
         cabal v2-build all
         cabal v2-haddock
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.8.4', '8.10.3', '9.0.1']
+        ghc: ['8.8.4', '8.10.4', '9.0.1']
         cabal: ['3.4.0.0']
 
       fail-fast: false

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -41,7 +41,7 @@ library
                        System.LibFuse3.Utils
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.11 && <4.15
+  build-depends:       base >=4.11 && <4.16
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*


### PR DESCRIPTION
Raises the upper bound of `base` to allow `base-4.15.0.0`, which should enable ghc-9.0.1 to build this package.

The older versions of GHCs, namely 8.4.4 and 8.6.5 were dropped from GitHub Actions.