### PR TITLE
Allow time-1.12

### DIFF
--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -45,7 +45,7 @@ library
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*
-                     , time >=1.6 && <1.12
+                     , time >=1.6 && <1.13
                      , unix ==2.7.*
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src


### PR DESCRIPTION
The exclusive upper bound of `time` was raised from `1.12` to `1.13` to support [`time-1.12`](https://hackage.haskell.org/package/time-1.12).

Tested with `--allow-newer='*:time'` because some of the dependencies accepts `time<1.12` only.