### PR TITLE
Allow base-4.16

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,9 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  # also run every Sunday in attempt to detect out-of-date version bounds
-  schedule:
-  - cron: "0 0 * * 0"
 
 jobs:
   build:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.8.4', '8.10.4', '9.0.1']
+        ghc: ['8.8.4', '8.10.7', '9.0.1']
         cabal: ['3.6.2.0']
 
       fail-fast: false

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['8.8.4', '8.10.4', '9.0.1']
-        cabal: ['3.4.0.0']
+        cabal: ['3.6.2.0']
 
       fail-fast: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install -y libfuse3-dev fuse3
 
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -41,7 +41,7 @@ library
                        System.LibFuse3.Utils
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.11 && <4.16
+  build-depends:       base >=4.11 && <4.17
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -45,7 +45,7 @@ library
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*
-                     , time >=1.6 && <1.13
+                     , time >=1.6 && <1.14
                      , unix ==2.7.*
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src


### PR DESCRIPTION
Raise the upper bound of `base` to allow base-4.16.0.0 so that this library is buildable with ghc-9.2.1.

As of now, the examples and the benchmark don't build with base-4.16.0.0 but the library itself and the tests do, and the tests pass.

This PR includes some minor cleanups. The CI settings are updated (in particular the scheduled job is removed), and time-1.13 is allowed (but never actually used because it is blacklisted).