### PR TITLE
Update dependencies and support unix-2.8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for libfuse3
 
+## 0.1.3.0 -- YYYY-MM-DD
+
+* Added support for `base-4.17.0.0` (ghc-9.4).
+* Added support for `unix-2.8.0.0`.
+
 ## 0.1.2.1 -- 2022-05-20
 
 * Enabled build for Haskell Stack ([#16](https://github.com/matil019/haskell-libfuse3/pull/16), thanks to @modotte)

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Haskell libfuse3 package], [0.1.2.1])
+AC_INIT([Haskell libfuse3 package], [0.1.3.0])
 
 # Safety check: Ensure that we are in the correct source directory.
 AC_CONFIG_SRCDIR([libfuse3.cabal])

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -41,7 +41,7 @@ library
                        System.LibFuse3.Utils
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.11 && <4.17
+  build-depends:       base >=4.11 && <4.18
                      , bytestring >=0.10.8 && <0.12
                      , clock ==0.8.*
                      , resourcet ==1.2.*

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                libfuse3
-version:             0.1.2.1
+version:             0.1.3.0
 synopsis:            A Haskell binding for libfuse-3.x
 description:         Bindings for libfuse, the FUSE userspace reference implementation, of version 3.x. Compatible with Linux.
 -- bug-reports:

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -46,8 +46,7 @@ library
                      , clock ==0.8.*
                      , resourcet ==1.2.*
                      , time >=1.6 && <1.14
-                     -- TODO when upgrading `unix`, check whether System.LibFuse3.FileStat can be replaced with System.Posix.Files.FileStatus
-                     , unix ==2.7.*
+                     , unix >=2.7 && <2.9
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src
   include-dirs:        include

--- a/src/System/LibFuse3/FileStat.hsc
+++ b/src/System/LibFuse3/FileStat.hsc
@@ -23,6 +23,8 @@ import System.Posix.Types
 
 import qualified Foreign
 
+-- TODO mention changes in unix-2.8.0.0? how about FileSystemStats?
+
 -- | A file status a.k.a. metadata.
 --
 -- The differences from `System.Posix.Files.FileStatus` are:

--- a/src/System/LibFuse3/FileStat.hsc
+++ b/src/System/LibFuse3/FileStat.hsc
@@ -23,8 +23,6 @@ import System.Posix.Types
 
 import qualified Foreign
 
--- TODO mention changes in unix-2.8.0.0? how about FileSystemStats?
-
 -- | A file status a.k.a. metadata.
 --
 -- The differences from `System.Posix.Files.FileStatus` are:
@@ -32,6 +30,8 @@ import qualified Foreign
 --   - Is a record type with a `Storable` instance.
 --
 --   - Has an extra field `blockCount`.
+--
+--       - An equivalent accessor @fileBlocks@ was added in unix-2.8.0.0, but it is a @Maybe@.
 --
 --   - Provides an exact representation (`TimeSpec`) of the time fields without converting to `Date.Time.Clock.POSIX.POSIXTime`.
 --
@@ -62,6 +62,7 @@ data FileStat = FileStat
     fileSize :: FileOffset
   , -- | Number of 512B blocks allocated. @st_blocks@
     blockCount :: CBlkSize -- see also: https://github.com/haskell/unix/pull/78/files
+                           -- TODO change the type to CBlkCnt (breaking change)
   -- these assumes Linux >= 2.6
   , -- | Time of last access. @st_atim@
     accessTimeHiRes :: TimeSpec

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -495,6 +495,7 @@ resCFuseOperations ops handlerRaw = do
   peekOpenFileFlagsAndMode :: Ptr C.FuseFileInfo -> IO (OpenFileFlags, OpenMode)
   peekOpenFileFlagsAndMode pFuseFileInfo = do
     (flags :: CInt) <- (#peek struct fuse_file_info, flags) pFuseFileInfo
+    -- TODO initialize missing fields added at unix-2.8.0.0; this means CPPs are needed
     let openFileFlags = OpenFileFlags
           { append   = testBitSet flags (#const O_APPEND)
           , nonBlock = testBitSet flags (#const O_NONBLOCK)

--- a/src/System/LibFuse3/Internal.hsc
+++ b/src/System/LibFuse3/Internal.hsc
@@ -499,9 +499,7 @@ resCFuseOperations ops handlerRaw = do
           { System.Posix.IO.append   = testBitSet flags (#const O_APPEND)
           , System.Posix.IO.nonBlock = testBitSet flags (#const O_NONBLOCK)
           , System.Posix.IO.trunc    = testBitSet flags (#const O_TRUNC)
-          -- TODO make sure that the other fields can be left False/Nothing (documented in FUSE?)
           }
-        -- TODO is this redundant in unix-2.8.0.0? if so, document it
         openMode
           | testBitSet flags (#const O_RDWR)   = ReadWrite
           | testBitSet flags (#const O_WRONLY) = WriteOnly

--- a/src/System/LibFuse3/Internal/Resource.hs
+++ b/src/System/LibFuse3/Internal/Resource.hs
@@ -27,7 +27,9 @@ daemonizeResourceT res = do
         throwIO e
       stateCleanupChecked Nothing istate
     -- cleanup actions are discarded because the child will run them
-    exitImmediately ExitSuccess
+    _ <- exitImmediately ExitSuccess
+    -- this @undefined@ is required because in unix<2.8 @exitImmediately@ returns @IO ()@
+    -- instead of @IO a@
     undefined
 
 -- | `callocBytes` with `free` associated as a cleanup action.


### PR DESCRIPTION
Extends the upper bounds of `base` and `unix` to `<4.18` and `<2.19`, respectively.

Some of the code is updated to support `unix-2.8.0.0`. This uncovered an incorrect type, which is corrected in another PR.