### PR TITLE
Fix the type of FileStat.blockCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Revision history for libfuse3
 
-## 0.1.3.0 -- YYYY-MM-DD
+## 0.2.0.0 -- YYYY-MM-DD
+
+### Breaking changes
+
+* Fixed the type of `FileStat.blockCount` from `CBlkSize` to `CBlkCnt`.
+
+### Other changes
 
 * Added support for `base-4.17.0.0` (ghc-9.4).
 * Added support for `unix-2.8.0.0`.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Haskell libfuse3 package], [0.1.3.0])
+AC_INIT([Haskell libfuse3 package], [0.2.0.0])
 
 # Safety check: Ensure that we are in the correct source directory.
 AC_CONFIG_SRCDIR([libfuse3.cabal])

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                libfuse3
-version:             0.1.3.0
+version:             0.2.0.0
 synopsis:            A Haskell binding for libfuse-3.x
 description:         Bindings for libfuse, the FUSE userspace reference implementation, of version 3.x. Compatible with Linux.
 -- bug-reports:

--- a/src/System/LibFuse3/FileStat.hsc
+++ b/src/System/LibFuse3/FileStat.hsc
@@ -10,7 +10,7 @@ import System.Clock (TimeSpec)
 import System.Posix.Error (throwErrnoPathIfMinus1Retry_)
 import System.Posix.Internals (c_fstat, lstat, withFilePath)
 import System.Posix.Types
-  ( CBlkSize
+  ( CBlkCnt
   , DeviceID
   , Fd(Fd)
   , FileID
@@ -61,8 +61,7 @@ data FileStat = FileStat
   , -- | Total size, in bytes. @st_size@
     fileSize :: FileOffset
   , -- | Number of 512B blocks allocated. @st_blocks@
-    blockCount :: CBlkSize -- see also: https://github.com/haskell/unix/pull/78/files
-                           -- TODO change the type to CBlkCnt (breaking change)
+    blockCount :: CBlkCnt
   -- these assumes Linux >= 2.6
   , -- | Time of last access. @st_atim@
     accessTimeHiRes :: TimeSpec


### PR DESCRIPTION
It was defined as `CBlkSize` but it should be `CBlkCnt`, which represents `blkcnt_t`.