### PR TITLE
Fix examples to compile with unix-2.8

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,9 +33,6 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - name: Check cabal file
-      run: cabal check
-
     - name: Configure the build
       run: |
         cabal v2-configure --flags=examples --enable-tests --enable-documentation
@@ -76,6 +73,7 @@ jobs:
         cabal v2-configure --flags=examples --enable-tests --enable-documentation
         cabal v2-build all
         cabal v2-haddock
+        cabal check
 
     - name: Run tests
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -44,9 +44,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Check version bounds
-      run: cabal outdated --exit-code
-
     - name: Build
       run: |
         autoreconf -fiv

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,8 +25,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfuse3-dev fuse3
 
-    # TODO use v3
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - uses: haskell/actions/setup@v2
       id: setup
       with:
@@ -97,7 +97,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfuse3-dev fuse3
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - uses: haskell/actions/setup@v2
       name: Setup Stack
       with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,7 +10,7 @@ jobs:
   cabal:
 
     # libfuse3 requires ubuntu>=20.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
         cabal v2-run -- integtest
 
   stack:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ghc: ['9.0.2']

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install -y libfuse3-dev fuse3
 
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -77,10 +77,11 @@ jobs:
         sudo apt-get install -y libfuse3-dev fuse3
 
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       name: Setup Stack
       with:
         ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
         stack-version: ${{ matrix.stack }}
 
     - uses: actions/cache@v1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,30 +25,51 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfuse3-dev fuse3
 
+    # TODO use v3
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v2
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - name: Cache
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-cabal
+    - name: Check cabal file
+      run: cabal check
+
+    - name: Configure the build
+      run: |
+        cabal v2-configure --flags=examples --enable-tests --enable-documentation
+        cabal v2-build --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v3
+      id: cache
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-plan-${{ hashFiles('**/plan.json') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ghc }}-
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+          ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-
+
+    - name: Install dependencies
+      run: cabal v2-build all --only-dependencies
+
+    # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+    - name: Save cached dependencies
+      uses: actions/cache/save@v3
+      # Caches are immutable, trying to save with the same key would error.
+      if: ${{ !steps.cache.outputs.cache-hit
+        || steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}
 
     - name: Build
       run: |
         autoreconf -fiv
-        cabal v2-update
-        # Compile the sdist archive instead of the source tree to make sure the all required files are packaged in it
+        # Compile the sdist archive instead of the source tree to make sure the all required files
+        # (in particular, `./configure`) are packaged in it.
+        # This means we have to run `cabal v2-configure` with the exact same arguments again
         cabal v2-sdist
         tar -xf dist-newstyle/sdist/libfuse3-*.tar.gz
         cd libfuse3-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for libfuse3
 
+## 0.2.0.1 -- 2023-03-24
+
+* Fixed the example to compile with `unix-2.8`.
+
 ## 0.2.0.0 -- 2022-09-10
 
 ### Breaking changes

--- a/example/passthrough.hs
+++ b/example/passthrough.hs
@@ -30,15 +30,17 @@ import System.Posix.IO (OpenFileFlags, OpenMode(WriteOnly), closeFd, defaultFile
 import System.Posix.Types (ByteCount, COff(COff), CSsize(CSsize), DeviceID, Fd(Fd), FileMode, FileOffset, GroupID, UserID)
 
 import qualified System.LibFuse3.FuseConfig as FuseConfig
-import qualified System.Posix.IO
 import qualified XAttr
+
+#if MIN_VERSION_unix(2,8,0)
+import System.Posix.IO (creat)
+#endif
 
 openFdCompat :: FilePath -> OpenMode -> Maybe FileMode -> OpenFileFlags -> IO Fd
 #if MIN_VERSION_unix(2,8,0)
-openFdCompat path openMode mfileMode openFileFlags = openFd path openMode (openFileFlags{System.Posix.IO.creat = mfileMode})
+openFdCompat path openMode mfileMode openFileFlags = openFd path openMode (openFileFlags{creat = mfileMode})
 #else
--- Uses the qualified import to avoid triggering a warning (I don't want to make imports conditional)
-openFdCompat = System.Posix.IO.openFd
+openFdCompat = openFd
 #endif
 
 foreign import ccall "posix_fallocate"

--- a/example/statjson.hs
+++ b/example/statjson.hs
@@ -62,14 +62,16 @@ import System.Posix.Types (ByteCount, Fd, FileMode, FileOffset)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified System.Clock
-import qualified System.Posix.IO
+
+#if MIN_VERSION_unix(2,8,0)
+import System.Posix.IO (creat)
+#endif
 
 openFdCompat :: FilePath -> OpenMode -> Maybe FileMode -> OpenFileFlags -> IO Fd
 #if MIN_VERSION_unix(2,8,0)
-openFdCompat path openMode mfileMode openFileFlags = openFd path openMode (openFileFlags{System.Posix.IO.creat = mfileMode})
+openFdCompat path openMode mfileMode openFileFlags = openFd path openMode (openFileFlags{creat = mfileMode})
 #else
--- Uses the qualified import to avoid triggering a warning (I don't want to make imports conditional)
-openFdCompat = System.Posix.IO.openFd
+openFdCompat = openFd
 #endif
 
 -- | An outcome of an individual operation in a layer.


### PR DESCRIPTION
The example executables were not compatible with unix-2.8 due to the change to `openFd`.

Compatibility shims were added to make the examples compilable with both unix-2.7 and 2.8. The library is not affected.