### PR TITLE
Fix linker error and update dependencies etc

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,18 +16,24 @@ jobs:
       matrix:
         ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.4', '9.6.1']
         include:
-        # We stick to cabal-3.6.2.0, which is marked as "recommended" in ghcup,
-        # unless ghc is too new.
+        # We use cabal-3.12.1.0, which is marked as "recommended" by GHCup.
         - ghc: '8.10.7'
-          cabal: '3.6.2.0'
+          cabal: '3.12.1.10'
         - ghc: '9.0.2'
-          cabal: '3.6.2.0'
-        - ghc: '9.2.5'
-          cabal: '3.6.2.0'
-        - ghc: '9.4.4'
-          cabal: '3.10.1.0'
-        - ghc: '9.6.1'
-          cabal: '3.10.1.0'
+          cabal: '3.12.1.10'
+        - ghc: '9.2.8'
+          cabal: '3.12.1.10'
+        - ghc: '9.4.8'
+          cabal: '3.12.1.10'
+        - ghc: '9.6.7'
+          cabal: '3.12.1.10'
+        # Omit GitHub Actions for GHC versions which are newer than "recommended" by GHCup.
+        # - ghc: '9.8.4'
+        #   cabal: '3.12.1.10'
+        # - ghc: '9.10.2'
+        #   cabal: '3.12.1.10'
+        # - ghc: '9.12.2'
+        #   cabal: '3.12.1.10'
 
       fail-fast: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,27 +18,8 @@ jobs:
              # Omit GitHub Actions for GHC versions which are newer than "recommended" by GHCup.
              # , '9.8.4', '9.10.2', '9.12.2'
              ]
-        include:
         # We use cabal-3.12.1.0, which is marked as "recommended" by GHCup.
-        - ghc: '8.10.7'
-          cabal: '3.12.1.10'
-        - ghc: '9.0.2'
-          cabal: '3.12.1.10'
-        - ghc: '9.2.8'
-          cabal: '3.12.1.10'
-        - ghc: '9.4.8'
-          cabal: '3.12.1.10'
-        - ghc: '9.6.7'
-          cabal: '3.12.1.10'
-        # Omit GitHub Actions for GHC versions which are newer than "recommended" by GHCup.
-        # - ghc: '9.8.4'
-        #   cabal: '3.12.1.10'
-        # - ghc: '9.10.2'
-        #   cabal: '3.12.1.10'
-        # - ghc: '9.12.2'
-        #   cabal: '3.12.1.10'
-
-      fail-fast: false
+        cabal: ['3.12.1.0']
 
     steps:
     - name: Install libfuse3
@@ -46,9 +27,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libfuse3-dev fuse3
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -56,28 +37,30 @@ jobs:
 
     - name: Configure the build
       run: |
-        cabal v2-configure --flags=examples --enable-tests --enable-documentation
+        cabal v2-configure --flags=examples --enable-tests --disable-documentation
         cabal v2-build --dry-run
-        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+      # The last step generates dist-newstyle/cache/plan.json for the cache key.
 
     - name: Restore cached dependencies
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       id: cache
+      env:
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
       with:
         path: ${{ steps.setup.outputs.cabal-store }}
-        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-plan-${{ hashFiles('**/plan.json') }}
-        restore-keys: |
-          ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-
+        key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
-      run: cabal v2-build all --only-dependencies
+      # If we had an exact cache hit, the dependencies will be up to date.
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: cabal build all --only-dependencies
 
     # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
     - name: Save cached dependencies
-      uses: actions/cache/save@v3
-      # Caches are immutable, trying to save with the same key would error.
-      if: ${{ !steps.cache.outputs.cache-hit
-        || steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+      uses: actions/cache/save@v4
+      # If we had an exact cache hit, trying to save the cache would error because of key clash.
+      if: steps.cache.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.setup.outputs.cabal-store }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -88,57 +71,20 @@ jobs:
         # Compile the sdist archive instead of the source tree to make sure the all required files
         # (in particular, `./configure`) are packaged in it.
         # This means we have to run `cabal v2-configure` with the exact same arguments again
+        # as we did in the "Configure the build" step
         cabal v2-sdist
         tar -xf dist-newstyle/sdist/libfuse3-*.tar.gz
         cd libfuse3-*/
-        cabal v2-configure --flags=examples --enable-tests --enable-documentation
+        cabal v2-configure --flags=examples --enable-tests --disable-documentation
         cabal v2-build all
-        cabal v2-haddock
+        # We also build documentation and check cabal file against the sdist archive instead of the
+        # source tree.
+        cabal v2-haddock all --disable-documentation
+        # --disable-documentation disables building documentation for dependencies.
+        # The package's own documentation is still built,
+        # yet contains no links to the documentation of the dependencies.
         cabal check
 
     - name: Run tests
       run: |
-        cabal v2-run -- unittest
-        cabal v2-run -- integtest
-
-  stack:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ghc: ['9.0.2']
-        stack: ['2.7.5']
-      fail-fast: false
-
-    steps:
-
-    - name: Install libfuse3
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libfuse3-dev fuse3
-
-    - uses: actions/checkout@v3
-
-    - uses: haskell/actions/setup@v2
-      name: Setup Stack
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        enable-stack: true
-        stack-version: ${{ matrix.stack }}
-
-    - uses: actions/cache@v1
-      name: Cache ~/.stack
-      with:
-        path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
-
-    - name: Install dependencies
-      run: |
-        stack build --system-ghc --no-run-tests --no-run-benchmarks --only-dependencies
-
-    - name: Build
-      run: |
-        stack build --system-ghc --no-run-tests --no-run-benchmarks
-
-    - name: Run tests
-      run: |
-        stack test --system-ghc
+        cabal v2-test all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,7 +14,10 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.10.7', '9.0.2', '9.2.5', '9.4.4', '9.6.1']
+        ghc: [ '8.10.7', '9.0.2', '9.2.8', '9.4.8', '9.6.7'
+             # Omit GitHub Actions for GHC versions which are newer than "recommended" by GHCup.
+             # , '9.8.4', '9.10.2', '9.12.2'
+             ]
         include:
         # We use cabal-3.12.1.0, which is marked as "recommended" by GHCup.
         - ghc: '8.10.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.2.1.0 --
 
+* Raised upper bound: `base <4.22`, allowing ghc-9.8, 9.10 and 9.12.
 * Added a C wrapper function around `fuse_new`, which is new a function macro instead of an ordinary function since an unknown version of the upstream.
 
 ## 0.2.0.1 -- 2023-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ## 0.2.1.0 --
 
+* Fixed the benchmark to work with `unix-2.8.*`.
+* Added a C wrapper function around `fuse_new`, which is now a function macro instead of an ordinary function since an unknown version of the upstream.
 * Raised upper bound: `base <4.22`, allowing ghc-9.8, 9.10 and 9.12.
-* Added a C wrapper function around `fuse_new`, which is new a function macro instead of an ordinary function since an unknown version of the upstream.
 
 ## 0.2.0.1 -- 2023-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for libfuse3
 
+<!-- Memo: Stop supporting older GHCs when bumping a version -->
+
+## 0.2.1.0 --
+
+* Added a C wrapper function around `fuse_new`, which is new a function macro instead of an ordinary function since an unknown version of the upstream.
+
 ## 0.2.0.1 -- 2023-03-26
 
 * Fixed the example to compile with `unix-2.8`.

--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -1,0 +1,14 @@
+#include <fuse.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+// Wraps a call to `fuse_new`, which is a function macro since an unknown version.
+//
+// We can't use CApiFFI because fuse requires `FUSE_USE_VERSION` macro to be defined. Although we do
+// define it with a `-DFUSE_USE_VERSION=...` option using `libfuse3.buildinfo.in` and `configure.ac`,
+// we couldn't find out how for CApiFFI to respect the option.
+struct fuse * hs_libfuse3_fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data) {
+  return fuse_new(args, op, op_size, private_data);
+}

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Haskell libfuse3 package], [0.2.0.1])
+AC_INIT([Haskell libfuse3 package], [0.2.1.0])
 
 # Safety check: Ensure that we are in the correct source directory.
 AC_CONFIG_SRCDIR([libfuse3.cabal])

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -42,7 +42,7 @@ library
                        System.LibFuse3.Utils
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.14.3 && <4.19
+  build-depends:       base >=4.14.3 && <4.22
                      , bytestring >=0.10.8 && <0.13
                      , clock ==0.8.*
                      , resourcet >=1.2 && <1.4

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -42,7 +42,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.14.3 && <4.19
-                     , bytestring >=0.10.8 && <0.12
+                     , bytestring >=0.10.8 && <0.13
                      , clock ==0.8.*
                      , resourcet >=1.2 && <1.4
                      , time >=1.6 && <1.14

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                libfuse3
-version:             0.2.0.1
+version:             0.2.1.0
 synopsis:            A Haskell binding for libfuse-3.x
 description:         Bindings for libfuse, the FUSE userspace reference implementation, of version 3.x. Compatible with Linux.
 -- bug-reports:

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -20,6 +20,7 @@ extra-source-files:
   README.md
   configure
   configure.ac
+  cbits/cbits.c
   include/config.h.in
   libfuse3.buildinfo.in
 
@@ -50,6 +51,7 @@ library
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src
   include-dirs:        include
+  c-sources:           cbits/cbits.c
   default-language:    Haskell2010
   ghc-options:         -Wall -fdefer-typed-holes
 

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -137,7 +137,7 @@ executable statjson
                        , bytestring
                        , clock
                        , directory
-                       , filepath
+                       , filepath >=1.4.1
                        , unix
   else
     buildable: False

--- a/libfuse3.cabal
+++ b/libfuse3.cabal
@@ -46,7 +46,7 @@ library
                      , bytestring >=0.10.8 && <0.13
                      , clock ==0.8.*
                      , resourcet >=1.2 && <1.4
-                     , time >=1.6 && <1.14
+                     , time >=1.6 && <1.15
                      , unix >=2.7 && <2.9
   pkgconfig-depends:   fuse3
   hs-source-dirs:      src

--- a/src/System/LibFuse3/Internal/C.hsc
+++ b/src/System/LibFuse3/Internal/C.hsc
@@ -351,7 +351,7 @@ foreign import ccall safe "fuse_lowlevel_version"
 foreign import ccall safe "fuse_mount"
   fuse_mount :: Ptr StructFuse -> CString -> IO CInt
 
-foreign import ccall safe "fuse_new"
+foreign import ccall safe "hs_libfuse3_fuse_new"
   fuse_new :: Ptr FuseArgs -> Ptr FuseOperations -> CSize -> Ptr a -> IO (Ptr StructFuse)
 
 foreign import ccall safe "fuse_opt_free_args"


### PR DESCRIPTION
This PR contains multiple changes:

* Fixed the benchmark to work with `unix-2.8.*`.
* Added a C wrapper function around `fuse_new`, which is now a function macro instead of an ordinary function since an unknown version of the upstream.
* Raised upper bound: `base <4.22`, allowing ghc-9.8, 9.10 and 9.12.
